### PR TITLE
feat(monorepo):add transpile module to allow css module in monorepo

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -1,6 +1,5 @@
-module.exports = {
+const withTM = require("next-transpile-modules")(["ui"]);
+
+module.exports = withTM({
   reactStrictMode: true,
-  experimental: {
-    transpilePackages: ["ui"],
-  },
-};
+});

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,12 +16,13 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
-    "eslint": "7.32.0",
-    "eslint-config-custom": "*",
-    "tsconfig": "*",
     "@types/node": "^17.0.12",
     "@types/react": "^18.0.22",
     "@types/react-dom": "^18.0.7",
+    "eslint": "7.32.0",
+    "eslint-config-custom": "*",
+    "next-transpile-modules": "^10.0.0",
+    "tsconfig": "*",
     "typescript": "^4.5.3"
   }
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,5 @@
-module.exports = {
+const withTM = require("next-transpile-modules")(["ui"]);
+
+module.exports = withTM({
   reactStrictMode: true,
-  experimental: {
-    transpilePackages: ["ui"],
-  },
-};
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,12 +16,13 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
-    "eslint": "7.32.0",
-    "eslint-config-custom": "*",
-    "tsconfig": "*",
     "@types/node": "^17.0.12",
     "@types/react": "^18.0.22",
     "@types/react-dom": "^18.0.7",
+    "eslint": "7.32.0",
+    "eslint-config-custom": "*",
+    "next-transpile-modules": "^10.0.0",
+    "tsconfig": "*",
     "typescript": "^4.5.3"
   }
 }

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -4,7 +4,7 @@ export default function Web() {
   return (
     <div>
       <h1>Web</h1>
-      <Button />
+      <Button fancy />
     </div>
   );
 }

--- a/packages/ui/Button.tsx
+++ b/packages/ui/Button.tsx
@@ -1,4 +1,0 @@
-import * as React from "react";
-export const Button = () => {
-  return <button>Boop</button>;
-};

--- a/packages/ui/Button/component.tsx
+++ b/packages/ui/Button/component.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 
 import styles from "./styles.module.css";
 
-export const Button = ({ fancy }: { fancy?: bool }) => {
+export const Button = ({ fancy }: { fancy?: boolean }) => {
   const className = classNames({ [styles.fancyButton]: fancy });
   return <button className={className}>Boop</button>;
 };

--- a/packages/ui/Button/component.tsx
+++ b/packages/ui/Button/component.tsx
@@ -1,0 +1,10 @@
+import * as React from "react";
+
+import classNames from "classnames";
+
+import styles from "./styles.module.css";
+
+export const Button = ({ fancy }: { fancy?: bool }) => {
+  const className = classNames({ [styles.fancyButton]: fancy });
+  return <button className={className}>Boop</button>;
+};

--- a/packages/ui/Button/styles.module.css
+++ b/packages/ui/Button/styles.module.css
@@ -1,0 +1,19 @@
+.fancyButton {
+  font-size: 15px;
+  font-family: Arial;
+  width: 140px;
+  height: 50px;
+  border-width: 1px;
+  color: #fff;
+  border-color: #18ab29;
+  font-weight: bold;
+  border-top-left-radius: 28px;
+  border-top-right-radius: 28px;
+  border-bottom-left-radius: 28px;
+  border-bottom-right-radius: 28px;
+  text-shadow: 1px 1px 0px #2f6627;
+  background: #44c767;
+}
+.fancyButton:hover {
+  background: #5cbf2a;
+}

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -1,2 +1,2 @@
 import * as React from "react";
-export * from "./Button";
+export * from "./Button/component";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,5 +15,8 @@
     "react": "^18.2.0",
     "tsconfig": "*",
     "typescript": "^4.5.2"
+  },
+  "dependencies": {
+    "classnames": "^2.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,11 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
@@ -819,6 +824,14 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+enhanced-resolve@^5.10.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
+  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
 
 enquirer@^2.3.5:
   version "2.3.6"
@@ -1324,6 +1337,11 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
+graceful-fs@^4.2.4:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -1665,6 +1683,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+next-transpile-modules@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-10.0.0.tgz#7152880048835acb64d05fc7aa34910cbe7994da"
+  integrity sha512-FyeJ++Lm2Fq31gbThiRCrJlYpIY9QaI7A3TjuhQLzOix8ChQrvn5ny4MhfIthS5cy6+uK1AhDRvxVdW17y3Xdw==
+  dependencies:
+    enhanced-resolve "^5.10.0"
 
 next@13.0.0:
   version "13.0.0"
@@ -2109,6 +2134,11 @@ table@^6.0.9:
     slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
+
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### Overview

This PR is a test to see how easy is to iterate on the ui package and have it imported into one of the two next apps

Turns out css module doesn't work out of the box with the latest turborepo example and so the `next-transpile-modules` needs to be added to make it all working

in this example the UI button has a new prop called `fancy` that makes the button green, it is set to true on the web app but not on the docs site


Web 

![Screenshot 2022-12-15 at 6 16 45 PM](https://user-images.githubusercontent.com/3579758/207937800-b476837a-dc6c-473b-bec1-5ff5bfbea04d.png)


Docs
![Screenshot 2022-12-15 at 6 16 36 PM](https://user-images.githubusercontent.com/3579758/207937821-437d136e-a0b4-45d1-b423-22011ad6b1a1.png)

